### PR TITLE
Fix comment capitalization typo

### DIFF
--- a/main_order_tax_cancellations_eval.user.js
+++ b/main_order_tax_cancellations_eval.user.js
@@ -1135,7 +1135,7 @@ async function createPieChart(list, parentElement) {
   }
 
 
-    // Fetch a PDF using GM_xmlHttpRequest
+    // Fetch a PDF using GM_xmlhttpRequest
     function fetchPDF(url) {
         if (url && url.endsWith('.pdf')) {
             return new Promise((resolve, reject) => {


### PR DESCRIPTION
## Summary
- correct the spelling of `GM_xmlhttpRequest` in a comment

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_b_684fc12d2b60832ea64a9f129a21d3ca