### PR TITLE
Add auto update URL for main script

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Inwieweit dieses Tool wirklich hilfreich ist, kann ich nicht beurteilen, da die 
 3. Klicke auf **Raw**, um den Skript-Quelltext anzuzeigen.
 4. Violentmonkey erkennt das Skript automatisch und bietet die Installation an.
 5. Bestätige mit **Installieren**.
+6. Durch den im Skript hinterlegten `@updateURL` wird bei neuen Versionen automatisch ein Update angeboten.
 
 ## Verfügbare Skripte
 

--- a/main_order_tax_cancellations_eval.user.js
+++ b/main_order_tax_cancellations_eval.user.js
@@ -18,6 +18,8 @@
 // @grant       GM_deleteValue
 // @grant       GM_listValues
 // @grant       GM_setClipboard
+// @updateURL   https://raw.githubusercontent.com/hutauf/VineTaxTools/refs/heads/main/main_order_tax_cancellations_eval.user.js
+// @downloadURL https://raw.githubusercontent.com/hutauf/VineTaxTools/refs/heads/main/main_order_tax_cancellations_eval.user.js
 // @version     1.111111
 // @author      -
 // @description 09.01.2025


### PR DESCRIPTION
## Summary
- enable auto-updates for `main_order_tax_cancellations_eval.user.js`
- mention automatic updates in README

## Testing
- `node --test`

------
https://chatgpt.com/codex/tasks/task_b_686af04970a8832e84271236d94b0c97